### PR TITLE
Fix compilation for 32-bit architectures

### DIFF
--- a/fontconfig/expr.go
+++ b/fontconfig/expr.go
@@ -6,7 +6,7 @@ import (
 	"math"
 )
 
-type opKind uint // a flag might be added, see `withFlags` and `getOp`
+type opKind uint64 // a flag might be added, see `withFlags` and `getOp`
 
 const (
 	opInt opKind = iota
@@ -53,7 +53,7 @@ const (
 	opInvalid
 )
 
-func opWithFlags(x opKind, f int) opKind {
+func opWithFlags(x opKind, f int64) opKind {
 	return x | opKind(f)<<16
 }
 
@@ -61,8 +61,8 @@ func (x opKind) getOp() opKind {
 	return x & 0xffff
 }
 
-func (x opKind) getFlags() int {
-	return (int(x) & 0xffff0000) >> 16
+func (x opKind) getFlags() int64 {
+	return (int64(x) & 0xffff0000) >> 16
 }
 
 func (x opKind) String() string {

--- a/fontconfig/xml.go
+++ b/fontconfig/xml.go
@@ -1020,7 +1020,7 @@ func (parser *configParser) parseTest() error {
 		kind    matchKind
 		qual    uint8
 		compare opKind
-		flags   int
+		flags   int64
 		object  Object
 		last    = parser.p()
 	)

--- a/harfbuzz/langs/gen.go
+++ b/harfbuzz/langs/gen.go
@@ -1072,7 +1072,7 @@ var disambiguation = map[string]string{
 }
 
 func max(vs map[string]int) int {
-	m := -math.MinInt32
+	m := math.MinInt
 	for _, v := range vs {
 		if v > m {
 			m = v

--- a/harfbuzz/ot_use.go
+++ b/harfbuzz/ot_use.go
@@ -304,7 +304,7 @@ func reorderSyllableUse(buffer *Buffer, start, end int) {
 		/* Got a repha.  Reorder it towards the end, but before the first post-base
 		 * glyph. */
 		for i := start + 1; i < end; i++ {
-			isPostBaseGlyph := (1<<(info[i].complexCategory)&postBaseFlags64) != 0 ||
+			isPostBaseGlyph := (int64(1<<(info[i].complexCategory))&postBaseFlags64) != 0 ||
 				isHalantUse(&info[i])
 			if isPostBaseGlyph || i == end-1 {
 				/* If we hit a post-base glyph, move before it; otherwise move to the


### PR DESCRIPTION
This PR fixes issues that appear when building with `GOARCH=386 go build ./...`. These problems are breaking Gio builds, most commonly for 32-bit Android phones.

I was unable to completely run the test suite on my local system, so I can't be totally confident that I didn't introduce failures. Please check these changes carefully. I'm least confident about my change to the `max` helper function, as I don't understand the original reason for the starting value of `-math.MinInt32`.