### PR TITLE
make the pauseFunc a full type

### DIFF
--- a/harfbuzz/ot_map.go
+++ b/harfbuzz/ot_map.go
@@ -106,7 +106,7 @@ func (mb *otMapBuilder) addFeatureExt(tag tt.Tag, flags otMapFeatureFlags, value
 	mb.featureInfos = append(mb.featureInfos, info)
 }
 
-type pauseFunc = func(plan *otShapePlan, font *Font, buffer *Buffer)
+type pauseFunc func(plan *otShapePlan, font *Font, buffer *Buffer)
 
 func (mb *otMapBuilder) addPause(tableIndex int, fn pauseFunc) {
 	s := stageInfo{


### PR DESCRIPTION
Removed the alias mark as this seems to break gopherJS 1.17. I don't know if there are negative ramifications of this change, but as it is an internal type it seems fairly safe?