### PR TITLE
fonts/truetype: use package-level error

### DIFF
--- a/fonts/truetype/rd_outlines.go
+++ b/fonts/truetype/rd_outlines.go
@@ -141,9 +141,11 @@ func (f *Font) glyphDataFromGlyf(glyph GID) (fonts.GlyphOutline, error) {
 	return fonts.GlyphOutline{Segments: segments}, nil
 }
 
+var noCFFTable error = errors.New("no CFF table")
+
 func (f *Font) glyphDataFromCFF1(glyph GID) (fonts.GlyphOutline, error) {
 	if f.cff == nil {
-		return fonts.GlyphOutline{}, errors.New("no CFF table")
+		return fonts.GlyphOutline{}, noCFFTable
 	}
 	segments, _, err := f.cff.LoadGlyph(glyph)
 	if err != nil {


### PR DESCRIPTION
@dominikh pointed out to me that allocating this error in the function causes ~65K allocations per font load, so moving it to a package variable should reduce garbage collector churn and memory use during font loading.